### PR TITLE
Fixed issue with missing ZLIB libraries when linking filter_mixture_bam

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ add_executable(dropest dropest.cpp)
 target_link_libraries(dropest Estimation ${EST_LIBRARIES})
 
 add_executable(filter_mixture_bam utils/filter_mixture_bam.cpp)
-target_link_libraries(filter_mixture_bam ${BAMTOOLS_LIBRARIES} ${LIBRARIES})
+target_link_libraries(filter_mixture_bam ${BAMTOOLS_LIBRARIES} ${ZLIB_LIBRARIES} ${LIBRARIES})
 set_target_properties(filter_mixture_bam PROPERTIES RUNTIME_OUTPUT_DIRECTORY ./utils/)
 
 #TODO: check it


### PR DESCRIPTION
This addresses a problem when zlib library is not automatically found by the compiler when linking filter_mixture_bam binary which would throw a following error:
```
[ 92%] Linking CXX executable utils/filter_mixture_bam
/usr/bin/ld: /tools/bamtools/2.5.1/bin/../lib64/libbamtools.a(BgzfStream_p.cpp.o): undefined reference to symbol 'inflateInit2_'
/usr/lib64/libz.so.1: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [utils/filter_mixture_bam] Error 1
make[1]: *** [CMakeFiles/filter_mixture_bam.dir/all] Error 2
make: *** [all] Error 2
```
This change provides zlib libraries for linking as found by cmake (automatically or as specified by the user through -DZLIB_LIBRARIES or -DZLIB_INCLUDE_DIRS flags).
