### PR TITLE
Please make changes for compatibility with new versions of boost. 

### DIFF
--- a/Tests/TestEstimation.cpp
+++ b/Tests/TestEstimation.cpp
@@ -1,7 +1,7 @@
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE tests
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Estimation/CellsDataContainer.h"
 

--- a/Tests/TestEstimationMergeProbs.cpp
+++ b/Tests/TestEstimationMergeProbs.cpp
@@ -1,7 +1,7 @@
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE tests
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <boost/unordered_map.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 

--- a/Tests/TestTagsSearch.cpp
+++ b/Tests/TestTagsSearch.cpp
@@ -1,7 +1,7 @@
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE tests
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "TagsSearch/FixPosSpacerTagsFinder.h"
 #include "TagsSearch/SpacerFinder.h"

--- a/Tests/TestTools.cpp
+++ b/Tests/TestTools.cpp
@@ -3,7 +3,7 @@
 
 #include <iostream>
 #include <fstream>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <boost/unordered_map.hpp>
 #include <Tools/ReadParameters.h>
 #include <Tools/GeneAnnotation/RefGenesContainer.h>


### PR DESCRIPTION
Proper includes should be:
```
#include <boost/test/included/unit_test.hpp>
```
not 
```
#include <boost/test/unit_test.hpp>
```
[see here](https://www.boost.org/doc/libs/1_67_0/libs/test/doc/html/boost_test/tests_organization/test_cases/test_organization_nullary.html). Thanks!